### PR TITLE
[feat] Add DeleteDeviceServiceEnvVar API (R2P-638,R2P-604)

### DIFF
--- a/cloud_client.go
+++ b/cloud_client.go
@@ -38,6 +38,7 @@ type CloudClient interface {
 	GetFleetEnvVars(ctx context.Context, name string) ([]FleetEnvVar, error)
 	GetServiceEnvVars(ctx context.Context, fleetName string) ([]ServiceEnvVar, error)
 	GetDeviceServiceEnvVars(ctx context.Context, balenaDeviceUUID string) ([]DeviceServiceEnvVar, error)
+	DeleteDeviceServiceEnvVar(ctx context.Context, balenaDeviceUUID string, envVarID int) error
 	SetDeviceName(ctx context.Context, balenaDeviceUUID, name string) error
 	DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, headerSetter HeaderSetter) (string, error)
 	MoveDeviceToFleet(ctx context.Context, balenaDeviceUUID, fleetName string) error
@@ -477,6 +478,27 @@ func (b *cloudClient) GetDeviceServiceEnvVars(
 
 	balenaResult := response.Result().(*Response[DeviceServiceEnvVar])
 	return balenaResult.D, nil
+}
+
+func (b *cloudClient) DeleteDeviceServiceEnvVar(
+	ctx context.Context, balenaDeviceUUID string, envVarID int,
+) error {
+	if !IsValidBalenaDeviceUUID(balenaDeviceUUID) {
+		return ErrInvalidBalenaDeviceUUID
+	}
+
+	response, err := b.httpClient.R().
+		SetContext(ctx).
+		Delete("/v6/device_service_environment_variable(" + strconv.Itoa(envVarID) + ")")
+	if err != nil {
+		return fmt.Errorf("failed performing request to delete device(%s) service env var(%d): %w", balenaDeviceUUID, envVarID, err)
+	}
+
+	if response.IsError() {
+		return fmt.Errorf("error deleting device(%s) service env var(%d): %s", balenaDeviceUUID, envVarID, response.Body())
+	}
+
+	return nil
 }
 
 func (b *cloudClient) SetDeviceName(ctx context.Context, balenaDeviceUUID, name string) error {

--- a/cloud_client_mock.go
+++ b/cloud_client_mock.go
@@ -93,6 +93,11 @@ func (m *mockCloudClient) GetServiceEnvVars(ctx context.Context, fleetName strin
 	return []ServiceEnvVar{}, nil
 }
 
+// DeleteDeviceServiceEnvVar implements CloudClient.
+func (m *mockCloudClient) DeleteDeviceServiceEnvVar(ctx context.Context, balenaDeviceUUID string, envVarID int) error {
+	return nil
+}
+
 // HostLogin implements CloudClient.
 func (m *mockCloudClient) HostLogin(token string) error {
 	return nil


### PR DESCRIPTION
## Jira Issue

[R2P-638: Add delete endpoint to gobalena](https://ces1.atlassian.net/browse/R2P-638)

## Implementation

<!--

Some description of HOW you implemented the linked issue. Perhaps give a high
level description of the program flow. Did you need to refactor something? What
tradeoffs did you take? Are there things in here which you'd particularly like
people to pay close attention to?

-->

* Just added another delete endpoint specifically for device _service_ env variables.
* Also i added a device filter on both variables, to filter by device id. I am not sure this is necessary, but I am copying the Update* function(s) which do this.
* Tested it manually in conjunction with code in the device manager, branch [R2P-604-Expose-a-device-manager-repo-endpoint-that-allows-updates-to-certain-extended-devices-properties](https://github.com/Round2POS/device-manager/tree/R2P-604-Expose-a-device-manager-repo-endpoint-that-allows-updates-to-certain-extended-devices-properties), draft PR:  [R2P-604: Expose device-manager endpoint: Update Balena ENV #23
](https://github.com/Round2POS/device-manager/pull/23).

## Screenshots

| Before | After |
| ------ | ----- |
|    N/A    |    N/A   |
