### PR TITLE
[feat] get device type in details (R2P-1070)

### DIFF
--- a/cloud_client.go
+++ b/cloud_client.go
@@ -17,7 +17,7 @@ const (
 	DeviceTypeSurfacePro6 DeviceType = "surface-pro-6"
 
 	DeviceQuerySelector           = "$select=id,uuid,ip_address,mac_address,public_address,device_name,os_version,os_variant,supervisor_version,is_online,last_connectivity_event,is_web_accessible,latitude,longitude,location,created_at,overall_status"
-	DeviceDetailsQuerySelector    = "$expand=is_running__release($expand=is_created_by__user($select=id,username,created_at),release_tag($select=tag_key,value,id)),should_be_running__release($expand=is_created_by__user($select=id,username,created_at),release_tag($select=tag_key,value,id)),belongs_to__application($select=id,app_name)"
+	DeviceDetailsQuerySelector    = "$expand=is_running__release($expand=is_created_by__user($select=id,username,created_at),release_tag($select=tag_key,value,id)),should_be_running__release($expand=is_created_by__user($select=id,username,created_at),release_tag($select=tag_key,value,id)),belongs_to__application($select=id,app_name),is_of__device_type($select=slug,name)"
 	FleetReleasesQuerySelect      = "$expand=is_created_by__user($select=id,username,created_at),is_running_on__device/$count,release_tag($select=tag_key,value,id)"
 	OrderByCreatedAtQuerySelector = "$orderby=created_at%20desc"
 )

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -16,7 +16,8 @@ const (
 	DeviceTypeSurfaceGo   DeviceType = "surface-go"
 	DeviceTypeSurfacePro6 DeviceType = "surface-pro-6"
 
-	DeviceQuerySelector           = "$select=id,uuid,ip_address,mac_address,public_address,device_name,os_version,os_variant,supervisor_version,is_online,last_connectivity_event,is_web_accessible,latitude,longitude,location,created_at,overall_status"
+	DeviceQuerySelector = "$select=id,uuid,ip_address,mac_address,public_address,device_name,os_version,os_variant,supervisor_version,is_online,last_connectivity_event,is_web_accessible,latitude,longitude,location,created_at,overall_status"
+	// See <https://docs.balena.io/reference/api/resources/device/>.
 	DeviceDetailsQuerySelector    = "$expand=is_running__release($expand=is_created_by__user($select=id,username,created_at),release_tag($select=tag_key,value,id)),should_be_running__release($expand=is_created_by__user($select=id,username,created_at),release_tag($select=tag_key,value,id)),belongs_to__application($select=id,app_name),is_of__device_type($select=slug,name)"
 	FleetReleasesQuerySelect      = "$expand=is_created_by__user($select=id,username,created_at),is_running_on__device/$count,release_tag($select=tag_key,value,id)"
 	OrderByCreatedAtQuerySelector = "$orderby=created_at%20desc"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Round2POS/gobalena/v2
 
-go 1.21.5
+go 1.23.12
 
 require (
 	github.com/go-resty/resty/v2 v2.16.0

--- a/models.go
+++ b/models.go
@@ -82,6 +82,10 @@ type Device struct {
 	ShouldBeRunningRelease []Release    `json:"should_be_running__release"`
 	BelongsToApplication   []FleetShort `json:"belongs_to__application"`
 	OverallStatus          string       `json:"overall_status"`
+	IsOfDeviceType         []struct {
+		Slug DeviceType `json:"slug"`
+		Name string     `json:"name"`
+	} `json:"is_of__device_type"`
 }
 
 type DeviceID struct {

--- a/test/e2e/crud_envs.go
+++ b/test/e2e/crud_envs.go
@@ -28,7 +28,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/Round2POS/gobalena"
+	"github.com/Round2POS/gobalena/v2"
 )
 
 // Utility function to delete a device env var with a given name, if it exists.


### PR DESCRIPTION
## Jira Issue

[R2P-1070: Make Staging Device Manager usable](https://ces1.atlassian.net/browse/R2P-1070)

## Implementation

<!--

Some description of HOW you implemented the linked issue. Perhaps give a high
level description of the program flow. Did you need to refactor something? What
tradeoffs did you take? Are there things in here which you'd particularly like
people to pay close attention to?

-->

- To create a new device in the device manager (Draft PR: https://github.com/Round2POS/device-manager/pull/35), the device type (e.g "generic") must be known.
- I add a request to the `/v7/device` query to "expand" the attribute `is_of__device_type($select=slug,name)`, which returns this information. Found by chatgpt, trial and error. OData sucks. Tested in conjunction with the DM draft PR.

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
