### PR TITLE
Prepare for release v2.5.0

### DIFF
--- a/cloud_client.go
+++ b/cloud_client.go
@@ -639,8 +639,6 @@ func (b *cloudClient) RestartAllServices(
 	return nil
 }
 
-
-
 func (b *cloudClient) DeleteDeviceServiceEnvVar(
 	ctx context.Context, balenaDeviceID, envVarID int,
 ) error {
@@ -920,11 +918,11 @@ func (b *cloudClient) Purge(
 
 	dev, err := b.GetDeviceDetails(ctx, balenaDeviceUUID)
 	if err != nil {
-		return fmt.Errorf("failed getting device(%s) details: %w", balenaDeviceUUID, err)
+		return fmt.Errorf("error purging device(%s): failed getting device(%s) details: %w", balenaDeviceUUID, err)
 	}
 
 	if len(dev.BelongsToApplication) == 0 {
-		return fmt.Errorf("device(%s) has no belongs_to__application returned from API", balenaDeviceUUID)
+		return fmt.Errorf("error purging device(%s): no belongs_to__application returned from API")
 	}
 
 	// This is the fleet id

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -33,6 +33,7 @@ type CloudClient interface {
 	GetFleet(ctx context.Context, name string) (*Fleet, error)
 	RegisterDevice(ctx context.Context, balenaDeviceUUID, fleetName string, deviceType DeviceType) error
 	DeleteDevice(ctx context.Context, balenaDeviceUUID string) error
+	Purge(ctx context.Context, balenaDeviceUUID string, force bool) error
 
 	CreateDeviceEnvVar(ctx context.Context, balenaDeviceUUID, key string, value string) error
 	GetDeviceEnvVars(ctx context.Context, balenaDeviceUUID string) ([]DeviceEnvVar, error)
@@ -856,6 +857,49 @@ func (b *cloudClient) PinDeviceToRelease(
 
 	if response.IsError() {
 		return fmt.Errorf("error trying to pin device(%s) to release(%d): %s", balenaDeviceUUID, releaseID, response.Body())
+	}
+
+	return nil
+}
+
+func (b *cloudClient) Purge(
+	ctx context.Context,
+	balenaDeviceUUID string,
+	force bool,
+) error {
+	if !IsValidBalenaDeviceUUID(balenaDeviceUUID) {
+		return ErrInvalidBalenaDeviceUUID
+	}
+
+	dev, err := b.GetDeviceDetails(ctx, balenaDeviceUUID)
+	if err != nil {
+		return fmt.Errorf("failed getting device(%s) details: %w", balenaDeviceUUID, err)
+	}
+
+	if len(dev.BelongsToApplication) == 0 {
+		return fmt.Errorf("device(%s) has no belongs_to__application returned from API", balenaDeviceUUID)
+	}
+
+	// This is the fleet id
+	fleetID := dev.BelongsToApplication[0].ID
+
+	body := map[string]interface{}{
+		"uuid": balenaDeviceUUID,
+	}
+	if force {
+		body["data"] = map[string]interface{}{"force": true}
+	}
+
+	response, err := b.httpClient.R().
+		SetContext(ctx).
+		SetBody(body).
+		Post(fmt.Sprintf("/supervisor/v2/applications/%d/purge", fleetID))
+	if err != nil {
+		return fmt.Errorf("error purging device(%s): request failed: %w", balenaDeviceUUID, err)
+	}
+
+	if response.IsError() {
+		return fmt.Errorf("error purging device(%s): %s", balenaDeviceUUID, response.Body())
 	}
 
 	return nil

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -922,7 +922,7 @@ func (b *cloudClient) Purge(
 	}
 
 	if len(dev.BelongsToApplication) == 0 {
-		return fmt.Errorf("error purging device(%s): no belongs_to__application returned from API")
+		return fmt.Errorf("error purging device(%s): no belongs_to__application returned from API", balenaDeviceUUID)
 	}
 
 	// This is the fleet id

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -918,7 +918,7 @@ func (b *cloudClient) Purge(
 
 	dev, err := b.GetDeviceDetails(ctx, balenaDeviceUUID)
 	if err != nil {
-		return fmt.Errorf("error purging device(%s): failed getting device(%s) details: %w", balenaDeviceUUID, err)
+		return fmt.Errorf("error purging device(%s): failed getting device details: %w", balenaDeviceUUID, err)
 	}
 
 	if len(dev.BelongsToApplication) == 0 {

--- a/cloud_client_mock.go
+++ b/cloud_client_mock.go
@@ -147,3 +147,8 @@ func (m *mockCloudClient) UpdateDeviceServiceEnvVar(ctx context.Context, balenaD
 func (m *mockCloudClient) ForceApply(ctx context.Context, balenaDeviceUUID string) error {
 	return nil
 }
+
+// Purge implements CloudClient.
+func (m *mockCloudClient) Purge(ctx context.Context, balenaDeviceUUID string, force bool) error {
+	return nil
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new supervisor-level operation that can forcibly purge a device, which can be destructive if invoked incorrectly; otherwise the change is localized to the client interface and mock.
> 
> **Overview**
> Adds a new `CloudClient.Purge(ctx, uuid, force)` method and implementation that looks up the device’s fleet ID via `GetDeviceDetails` and calls the supervisor `POST /supervisor/v2/applications/{fleetID}/purge` endpoint, optionally passing `force`.
> 
> Updates the mock client to satisfy the extended interface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e790617a84fa196c36e85e1f3ff1f0a536347db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->