### PR TITLE
[DM-30] Gobalena:  Purge device code review changes

### DIFF
--- a/cloud_client.go
+++ b/cloud_client.go
@@ -639,8 +639,6 @@ func (b *cloudClient) RestartAllServices(
 	return nil
 }
 
-
-
 func (b *cloudClient) DeleteDeviceServiceEnvVar(
 	ctx context.Context, balenaDeviceID, envVarID int,
 ) error {
@@ -920,11 +918,11 @@ func (b *cloudClient) Purge(
 
 	dev, err := b.GetDeviceDetails(ctx, balenaDeviceUUID)
 	if err != nil {
-		return fmt.Errorf("failed getting device(%s) details: %w", balenaDeviceUUID, err)
+		return fmt.Errorf("error purging device(%s): failed getting device(%s) details: %w", balenaDeviceUUID, err)
 	}
 
 	if len(dev.BelongsToApplication) == 0 {
-		return fmt.Errorf("device(%s) has no belongs_to__application returned from API", balenaDeviceUUID)
+		return fmt.Errorf("error purging device(%s): no belongs_to__application returned from API")
 	}
 
 	// This is the fleet id

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -922,7 +922,7 @@ func (b *cloudClient) Purge(
 	}
 
 	if len(dev.BelongsToApplication) == 0 {
-		return fmt.Errorf("error purging device(%s): no belongs_to__application returned from API")
+		return fmt.Errorf("error purging device(%s): no belongs_to__application returned from API", balenaDeviceUUID)
 	}
 
 	// This is the fleet id

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -918,7 +918,7 @@ func (b *cloudClient) Purge(
 
 	dev, err := b.GetDeviceDetails(ctx, balenaDeviceUUID)
 	if err != nil {
-		return fmt.Errorf("error purging device(%s): failed getting device(%s) details: %w", balenaDeviceUUID, err)
+		return fmt.Errorf("error purging device(%s): failed getting device details: %w", balenaDeviceUUID, err)
 	}
 
 	if len(dev.BelongsToApplication) == 0 {


### PR DESCRIPTION
## Jira Issue

https://ces1.atlassian.net/browse/DM-30

## Implementation

PR implements code review changes prior to purge device changes being merged with main.

Specifically, code review from the following branch:

https://github.com/Round2POS/gobalena/pull/16

<!--

Some description of HOW you implemented the linked issue. Perhaps give a high
level description of the program flow. Did you need to refactor something? What
tradeoffs did you take? Are there things in here which you'd particularly like
people to pay close attention to?

-->

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
|        |       |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts error message text/formatting and file whitespace; no API behavior or request logic changes.
> 
> **Overview**
> Tightens `Purge` error handling by rewriting the early error messages to consistently include `error purging device(<uuid>)` context (including failures to fetch device details and missing `belongs_to__application`).
> 
> Also removes stray blank lines near `DeleteDeviceServiceEnvVar` and restores the trailing newline in `cloud_client.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7697ad0d3e8b195d2bb7c826f4667de4891dd854. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->