### PR TITLE
[WEB-1] GoBalena: Update devices by merchant

### DIFF
--- a/cloud_client.go
+++ b/cloud_client.go
@@ -887,6 +887,9 @@ func (b *cloudClient) PinDeviceToRelease(
 	balenaDeviceUUID string,
 	releaseID int,
 ) error {
+	if releaseID <= 0 {
+		return ErrInvalidReleaseID
+	}
 	if !IsValidBalenaDeviceUUID(balenaDeviceUUID) {
 		return ErrInvalidBalenaDeviceUUID
 	}
@@ -894,7 +897,7 @@ func (b *cloudClient) PinDeviceToRelease(
 	response, err := b.httpClient.R().
 		SetContext(ctx).
 		SetBody(map[string]interface{}{
-			"should_be_running__release": strconv.Itoa(releaseID),
+			"should_be_running__release": releaseID,
 		}).
 		Patch("/v6/device(uuid='" + balenaDeviceUUID + "')")
 	if err != nil {
@@ -913,6 +916,9 @@ func (b *cloudClient) PinMerchantDevicesToRelease(
 	balenaDeviceUUIDs []string,
 	releaseID int,
 ) error {
+	if releaseID <= 0 {
+		return ErrInvalidReleaseID
+	}
 	if len(balenaDeviceUUIDs) == 0 {
 		return fmt.Errorf("no device UUIDs provided")
 	}

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -60,6 +60,7 @@ type CloudClient interface {
 	HostLogin(token string) error
 	GetFleetReleases(ctx context.Context, name string) ([]Release, error)
 	PinDeviceToRelease(ctx context.Context, balenaDeviceUUID string, releaseID int) error
+	PinMerchantDevicesToRelease(ctx context.Context, balenaDeviceUUIDs []string, releaseID int) error
 }
 
 type cloudClient struct {
@@ -902,6 +903,44 @@ func (b *cloudClient) PinDeviceToRelease(
 
 	if response.IsError() {
 		return fmt.Errorf("error trying to pin device(%s) to release(%d): %s", balenaDeviceUUID, releaseID, response.Body())
+	}
+
+	return nil
+}
+
+func (b *cloudClient) PinMerchantDevicesToRelease(
+	ctx context.Context,
+	balenaDeviceUUIDs []string,
+	releaseID int,
+) error {
+	if len(balenaDeviceUUIDs) == 0 {
+		return fmt.Errorf("no device UUIDs provided")
+	}
+
+	filter := ""
+	for i, uuid := range balenaDeviceUUIDs {
+		if !IsValidBalenaDeviceUUID(uuid) {
+			return ErrInvalidBalenaDeviceUUID
+		}
+
+		filter += "'" + uuid + "'"
+		if i < len(balenaDeviceUUIDs)-1 {
+			filter += ","
+		}
+	}
+
+	response, err := b.httpClient.R().
+		SetContext(ctx).
+		SetBody(map[string]interface{}{
+			"should_be_running__release": strconv.Itoa(releaseID),
+		}).
+		Patch("/v6/device?$filter=uuid%20in(" + filter + ")")
+	if err != nil {
+		return fmt.Errorf("failed performing request to pin devices to release(%d): %w", releaseID, err)
+	}
+
+	if response.IsError() {
+		return fmt.Errorf("error trying to pin devices to release(%d): %s", releaseID, response.Body())
 	}
 
 	return nil

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -911,41 +911,6 @@ func (b *cloudClient) PinDeviceToRelease(
 	return nil
 }
 
-func (b *cloudClient) PinMerchantDevicesToRelease(
-	ctx context.Context,
-	balenaDeviceUUIDs []string,
-	releaseID int,
-) error {
-	if releaseID <= 0 {
-		return ErrInvalidReleaseID
-	}
-	if len(balenaDeviceUUIDs) == 0 {
-		return fmt.Errorf("no device UUIDs provided")
-	}
-
-	for _, uuid := range balenaDeviceUUIDs {
-		if !IsValidBalenaDeviceUUID(uuid) {
-			return ErrInvalidBalenaDeviceUUID
-		}
-
-		response, err := b.httpClient.R().
-			SetContext(ctx).
-			SetBody(map[string]interface{}{
-				"should_be_running__release": releaseID,
-			}).
-			Patch("/v6/device(uuid='" + uuid + "')")
-		if err != nil {
-			return fmt.Errorf("failed performing request to pin device(%s) to release(%d): %w", uuid, releaseID, err)
-		}
-
-		if response.IsError() {
-			return fmt.Errorf("error trying to pin device(%s) to release(%d): %s", uuid, releaseID, response.Body())
-		}
-	}
-
-	return nil
-}
-
 func (b *cloudClient) Purge(
 	ctx context.Context,
 	balenaDeviceUUID string,

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -917,30 +917,24 @@ func (b *cloudClient) PinMerchantDevicesToRelease(
 		return fmt.Errorf("no device UUIDs provided")
 	}
 
-	filter := ""
-	for i, uuid := range balenaDeviceUUIDs {
+	for _, uuid := range balenaDeviceUUIDs {
 		if !IsValidBalenaDeviceUUID(uuid) {
 			return ErrInvalidBalenaDeviceUUID
 		}
 
-		filter += "'" + uuid + "'"
-		if i < len(balenaDeviceUUIDs)-1 {
-			filter += ","
+		response, err := b.httpClient.R().
+			SetContext(ctx).
+			SetBody(map[string]interface{}{
+				"should_be_running__release": releaseID,
+			}).
+			Patch("/v6/device(uuid='" + uuid + "')")
+		if err != nil {
+			return fmt.Errorf("failed performing request to pin device(%s) to release(%d): %w", uuid, releaseID, err)
 		}
-	}
 
-	response, err := b.httpClient.R().
-		SetContext(ctx).
-		SetBody(map[string]interface{}{
-			"should_be_running__release": strconv.Itoa(releaseID),
-		}).
-		Patch("/v6/device?$filter=uuid%20in(" + filter + ")")
-	if err != nil {
-		return fmt.Errorf("failed performing request to pin devices to release(%d): %w", releaseID, err)
-	}
-
-	if response.IsError() {
-		return fmt.Errorf("error trying to pin devices to release(%d): %s", releaseID, response.Body())
+		if response.IsError() {
+			return fmt.Errorf("error trying to pin device(%s) to release(%d): %s", uuid, releaseID, response.Body())
+		}
 	}
 
 	return nil

--- a/cloud_client.go
+++ b/cloud_client.go
@@ -60,7 +60,6 @@ type CloudClient interface {
 	HostLogin(token string) error
 	GetFleetReleases(ctx context.Context, name string) ([]Release, error)
 	PinDeviceToRelease(ctx context.Context, balenaDeviceUUID string, releaseID int) error
-	PinMerchantDevicesToRelease(ctx context.Context, balenaDeviceUUIDs []string, releaseID int) error
 }
 
 type cloudClient struct {

--- a/cloud_client_mock.go
+++ b/cloud_client_mock.go
@@ -123,6 +123,11 @@ func (m *mockCloudClient) PinDeviceToRelease(ctx context.Context, balenaDeviceUU
 	return nil
 }
 
+// PinMerchantDevicesToRelease implements CloudClient.
+func (m *mockCloudClient) PinMerchantDevicesToRelease(ctx context.Context, balenaDeviceUUIDs []string, releaseID int) error {
+	return nil
+}
+
 // RegisterDevice implements CloudClient.
 func (m *mockCloudClient) RegisterDevice(ctx context.Context, balenaDeviceUUID string, fleetName string, deviceType DeviceType) error {
 	return nil

--- a/cloud_client_mock.go
+++ b/cloud_client_mock.go
@@ -123,11 +123,6 @@ func (m *mockCloudClient) PinDeviceToRelease(ctx context.Context, balenaDeviceUU
 	return nil
 }
 
-// PinMerchantDevicesToRelease implements CloudClient.
-func (m *mockCloudClient) PinMerchantDevicesToRelease(ctx context.Context, balenaDeviceUUIDs []string, releaseID int) error {
-	return nil
-}
-
 // RegisterDevice implements CloudClient.
 func (m *mockCloudClient) RegisterDevice(ctx context.Context, balenaDeviceUUID string, fleetName string, deviceType DeviceType) error {
 	return nil

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,7 @@ import "errors"
 
 var (
 	ErrInvalidBalenaDeviceUUID = errors.New("invalid balena device uuid")
-
+	ErrInvalidMerchantUUID     = errors.New("invalid merchant uuid")
 	ErrResourceNotFound  = errors.New("resource not found")
 	ErrExpectedOneResult = errors.New("expected one result")
 	ErrEnvVarNotFound    = errors.New("env var not found")

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,6 @@ import "errors"
 
 var (
 	ErrInvalidBalenaDeviceUUID = errors.New("invalid balena device uuid")
-	ErrInvalidMerchantUUID     = errors.New("invalid merchant uuid")
 	ErrResourceNotFound  = errors.New("resource not found")
 	ErrExpectedOneResult = errors.New("expected one result")
 	ErrEnvVarNotFound    = errors.New("env var not found")

--- a/errors.go
+++ b/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrResourceNotFound  = errors.New("resource not found")
 	ErrExpectedOneResult = errors.New("expected one result")
 	ErrEnvVarNotFound    = errors.New("env var not found")
+	ErrInvalidReleaseID  = errors.New("invalid release ID: must be greater than 0")
 )


### PR DESCRIPTION
## Jira Issue

https://linear.app/r2pos/issue/WEB-1/gobalena-update-devices-by-merchant

## Implementation

Fixes device release pinning by adding a guard in PinDeviceToRelease that rejects non-positive releaseIDs (ErrInvalidReleaseID) and by sending should_be_running__release as a numeric value instead of a string.

Also introduces ErrInvalidMerchantUUID for upcoming merchant-related validation.

<!--

Some description of HOW you implemented the linked issue. Perhaps give a high
level description of the program flow. Did you need to refactor something? What
tradeoffs did you take? Are there things in here which you'd particularly like
people to pay close attention to?

-->

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
|        |       |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches device update behavior and request payloads; a bad assumption about Balena’s API typing could break pinning in production, though the change is small and scoped.
> 
> **Overview**
> Fixes device release pinning by updating `PinDeviceToRelease` to **reject non-positive `releaseID` values** and return a new `ErrInvalidReleaseID`.
> 
> Also changes the Balena PATCH payload so `should_be_running__release` is sent as an *integer* instead of a string, aligning with the API’s expected type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f544fb9790937c44e8da7ade8fafde767bf5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->