### PR TITLE
[POS-3490] Hot fix: Download ISO needs to use OS 6.12.2

### DIFF
--- a/cloud_client.go
+++ b/cloud_client.go
@@ -54,7 +54,7 @@ type CloudClient interface {
 	DeleteDeviceServiceEnvVar(ctx context.Context, balenaDeviceID, envVarID int) error
 
 	SetDeviceName(ctx context.Context, balenaDeviceUUID, name string) error
-	DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, headerSetter HeaderSetter) (string, error)
+	DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, version string, headerSetter HeaderSetter) (string, error)
 	MoveDeviceToFleet(ctx context.Context, balenaDeviceUUID, fleetName string) error
 	EnablePublicDeviceURL(ctx context.Context, balenaDeviceUUID string) error
 	HostLogin(token string) error
@@ -691,7 +691,7 @@ type HeaderSetter interface {
 
 func (b *cloudClient) DownloadOS(
 	ctx context.Context, writer io.Writer, fleet string,
-	deviceType DeviceType, headerSetter HeaderSetter,
+	deviceType DeviceType, version string, headerSetter HeaderSetter,
 ) (string, error) {
 	flt, err := b.GetFleet(ctx, fleet)
 	if err != nil {
@@ -704,7 +704,7 @@ func (b *cloudClient) DownloadOS(
 			"deviceType":      string(deviceType),
 			"appId":           fmt.Sprintf("%d", flt.ID),
 			"fileType":        ".zip",
-			"version":         "latest",
+			"version":         version,
 			"network":         "ethernet",
 			"developmentMode": "false",
 		}).

--- a/cloud_client_mock.go
+++ b/cloud_client_mock.go
@@ -34,7 +34,7 @@ func (m *mockCloudClient) DeleteDevice(ctx context.Context, balenaDeviceUUID str
 }
 
 // DownloadOS implements CloudClient.
-func (m *mockCloudClient) DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, headerSetter HeaderSetter) (string, error) {
+func (m *mockCloudClient) DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, version string, headerSetter HeaderSetter) (string, error) {
 	return "", nil
 }
 


### PR DESCRIPTION
## Jira Issue

https://linear.app/r2pos/issue/POS-3490/hot-fix-download-iso-needs-to-use-os-6122

## Implementation

DownloadOS previously hardcoded the OS version query param to "latest". Add a required `version string` parameter so callers can pin a specific balena OS version (e.g. 6.12.2) instead of always pulling the newest.

<!--

Some description of HOW you implemented the linked issue. Perhaps give a high
level description of the program flow. Did you need to refactor something? What
tradeoffs did you take? Are there things in here which you'd particularly like
people to pay close attention to?

-->

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |
|        |       |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change on CloudClient.DownloadOS; wrong or missing version at call sites could download unintended OS images for provisioning.
> 
> **Overview**
> **`DownloadOS`** no longer always requests Balena’s **latest** OS image. The **`CloudClient`** API and implementation now take a required **`version`** string, which is sent as the **`version`** query parameter on **`/download`**. Callers can pin a specific OS build (e.g. **6.12.2** for ISO downloads). The mock client signature is updated to match.
> 
> This is a **breaking interface change** for anything implementing or calling **`DownloadOS`**; those call sites must pass the desired version explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385d5000fb52608611e356027cbe5bf51fbc1907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->