### PR TITLE
Prepare for release v2.7.0

### DIFF
--- a/cloud_client.go
+++ b/cloud_client.go
@@ -54,7 +54,7 @@ type CloudClient interface {
 	DeleteDeviceServiceEnvVar(ctx context.Context, balenaDeviceID, envVarID int) error
 
 	SetDeviceName(ctx context.Context, balenaDeviceUUID, name string) error
-	DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, headerSetter HeaderSetter) (string, error)
+	DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, version string, headerSetter HeaderSetter) (string, error)
 	MoveDeviceToFleet(ctx context.Context, balenaDeviceUUID, fleetName string) error
 	EnablePublicDeviceURL(ctx context.Context, balenaDeviceUUID string) error
 	HostLogin(token string) error
@@ -691,7 +691,7 @@ type HeaderSetter interface {
 
 func (b *cloudClient) DownloadOS(
 	ctx context.Context, writer io.Writer, fleet string,
-	deviceType DeviceType, headerSetter HeaderSetter,
+	deviceType DeviceType, version string, headerSetter HeaderSetter,
 ) (string, error) {
 	flt, err := b.GetFleet(ctx, fleet)
 	if err != nil {
@@ -704,7 +704,7 @@ func (b *cloudClient) DownloadOS(
 			"deviceType":      string(deviceType),
 			"appId":           fmt.Sprintf("%d", flt.ID),
 			"fileType":        ".zip",
-			"version":         "latest",
+			"version":         version,
 			"network":         "ethernet",
 			"developmentMode": "false",
 		}).

--- a/cloud_client_mock.go
+++ b/cloud_client_mock.go
@@ -34,7 +34,7 @@ func (m *mockCloudClient) DeleteDevice(ctx context.Context, balenaDeviceUUID str
 }
 
 // DownloadOS implements CloudClient.
-func (m *mockCloudClient) DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, headerSetter HeaderSetter) (string, error) {
+func (m *mockCloudClient) DownloadOS(ctx context.Context, writer io.Writer, fleet string, deviceType DeviceType, version string, headerSetter HeaderSetter) (string, error) {
 	return "", nil
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking API change on CloudClient.DownloadOS requires all callers to pass a version; wrong values could download unintended OS images.
> 
> **Overview**
> **`CloudClient.DownloadOS`** now takes an explicit **`version`** argument instead of always requesting **`latest`** from the Balena download API.
> 
> The **`CloudClient`** interface, **`cloudClient`** implementation, and **`mockCloudClient`** were updated together so callers must pass the desired OS version string through to the `/download` query parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08044735afa2f23ff957c6bf2d720e0d82fe3975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->