### PR TITLE
Add Claude @claude PR review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,6 +4,11 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
 jobs:
   review:
     uses: Round2POS/.github/.github/workflows/claude-review.yml@main

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,10 @@
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+jobs:
+  review:
+    uses: Round2POS/.github/.github/workflows/claude-review.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds a caller workflow so commenting `@claude` on a PR triggers an automated review.

Logic lives in the org reusable workflow `Round2POS/.github/.github/workflows/claude-review.yml`.

**Note:** `@claude` only works once this is merged to the default branch, and requires the org secret `CLAUDE_CODE_OAUTH_TOKEN` + the Claude GitHub App installed on this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no application code changes; relies on inherited org secrets and a shared workflow pinned to `@main`.
> 
> **Overview**
> Adds a **GitHub Actions workflow** (`.github/workflows/claude.yml`) that runs on new **issue comments** and **pull request review comments**, delegating to the org reusable workflow `Round2POS/.github/.github/workflows/claude-review.yml@main` with `secrets: inherit`.
> 
> Grants `contents`, `pull-requests`, `issues`, and `id-token` **write** permissions so the shared review job can respond on PRs when someone comments `@claude` (after merge to default branch and with org secret `CLAUDE_CODE_OAUTH_TOKEN` + Claude GitHub App).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1690a2909e36693814c2258f191aa8b1aaa8180d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->